### PR TITLE
Add case studies section

### DIFF
--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -1,0 +1,154 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { FiArrowLeft, FiCalendar, FiCheck } from 'react-icons/fi'
+import Reveal from '../../components/Reveal'
+import { CAL_URL } from '../../lib/site'
+import { caseStudies, getCaseStudy } from '../data'
+
+export function generateStaticParams() {
+  return caseStudies.map((c) => ({ slug: c.slug }))
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const study = getCaseStudy(slug)
+  if (!study) return {}
+  return {
+    title: `${study.headline} · Case study · Extensa`,
+    description: study.subheadline,
+  }
+}
+
+export default async function CaseStudyPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const study = getCaseStudy(slug)
+  if (!study) notFound()
+
+  return (
+    <div className="bg-[--paper] text-[--ink]">
+      <main>
+        {/* Hero */}
+        <section className="bg-[--ink] text-white pt-28 sm:pt-36 pb-16 md:pb-24">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6">
+            <Link
+              href="/case-studies"
+              className="inline-flex items-center gap-2 text-sm text-white/60 hover:text-white transition-colors mb-10"
+            >
+              <FiArrowLeft className="w-4 h-4" />
+              All case studies
+            </Link>
+            <div className="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
+              <div className="animate-slide-in-left">
+                <p className="eyebrow text-[--signal] mb-5">Case study · {study.tag}</p>
+                <p className="font-display text-7xl md:text-8xl font-bold leading-none">{study.stat}</p>
+                <p className="mt-3 text-lg text-white/80">{study.statLabel}</p>
+              </div>
+              <div className="animate-slide-in-right">
+                <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold leading-[1.1] mb-5">
+                  {study.headline}
+                </h1>
+                <p className="text-lg text-white/70 leading-relaxed">{study.subheadline}</p>
+              </div>
+            </div>
+            <dl className="mt-14 pt-8 border-t border-white/15 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-6">
+              {study.meta.map((m) => (
+                <div key={m.label}>
+                  <dt className="font-mono text-xs uppercase tracking-wider text-white/50 mb-1">{m.label}</dt>
+                  <dd className="font-medium">{m.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+
+        {/* The situation before */}
+        <section className="py-16 md:py-24">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6">
+            <p className="eyebrow mb-3">01 · The situation before</p>
+            <h2 className="font-display text-3xl md:text-4xl font-bold mb-10 max-w-3xl">
+              {study.situationTitle}
+            </h2>
+            <div className="space-y-5">
+              {study.situation.map((s, i) => (
+                <Reveal key={s.title} delay={i * 80}>
+                  <div className="card card-accent p-6 md:p-8 flex gap-6">
+                    <span className="font-mono text-sm text-[--signal-deep] pt-1 shrink-0">
+                      0{i + 1}
+                    </span>
+                    <div>
+                      <h3 className="font-display text-xl font-semibold mb-2">{s.title}</h3>
+                      <p className="text-[--ink-soft] leading-relaxed">{s.body}</p>
+                    </div>
+                  </div>
+                </Reveal>
+              ))}
+            </div>
+            <Reveal delay={240}>
+              <blockquote className="mt-8 bg-[--ink] text-white/90 rounded-[14px] p-7 md:p-8 text-lg leading-relaxed">
+                {study.situationPullQuote}
+              </blockquote>
+            </Reveal>
+          </div>
+        </section>
+
+        <div className="bottleneck-divider max-w-6xl mx-auto px-4" aria-hidden="true" />
+
+        {/* What we built */}
+        <section className="py-16 md:py-24">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6">
+            <p className="eyebrow mb-3">02 · What we built</p>
+            <h2 className="font-display text-3xl md:text-4xl font-bold mb-10 max-w-3xl">{study.builtTitle}</h2>
+            <div className="grid md:grid-cols-3 gap-5">
+              {study.built.map((b, i) => (
+                <Reveal key={b.title} delay={i * 80} className="h-full">
+                  <div className="card p-6 h-full">
+                    <h3 className="font-display text-xl font-semibold mb-3">{b.title}</h3>
+                    <p className="text-[--ink-soft] leading-relaxed">{b.body}</p>
+                  </div>
+                </Reveal>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* What changed */}
+        <section className="section-tint py-16 md:py-24">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6">
+            <p className="eyebrow mb-3">03 · The result</p>
+            <h2 className="font-display text-3xl md:text-4xl font-bold mb-10">What changed</h2>
+            <ul className="grid sm:grid-cols-2 gap-4 max-w-4xl">
+              {study.changed.map((c, i) => (
+                <Reveal key={c} delay={i * 60}>
+                  <li className="card p-5 flex items-start gap-3 h-full">
+                    <FiCheck className="w-5 h-5 text-[--signal-deep] mt-0.5 shrink-0" />
+                    <span className="leading-relaxed">{c}</span>
+                  </li>
+                </Reveal>
+              ))}
+            </ul>
+            <p className="mt-10 text-[--ink-soft] text-lg leading-relaxed max-w-3xl">{study.patternNote}</p>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="bg-[--ink] text-white py-16 md:py-24">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 text-center">
+            <h2 className="font-display text-3xl md:text-4xl font-bold mb-5 leading-tight">
+              If your team is patching gaps in off-the-shelf platforms with people, there&apos;s probably a
+              custom system worth building instead.
+            </h2>
+            <a
+              href={CAL_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 bg-[--signal] text-[--ink] px-7 py-4 rounded-md font-semibold hover:bg-[--signal-deep] transition-colors mt-4"
+            >
+              <FiCalendar className="w-5 h-5" />
+              Book a 20-minute discovery call
+            </a>
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/app/case-studies/data.ts
+++ b/app/case-studies/data.ts
@@ -1,0 +1,85 @@
+// Case study content. Add a new entry here and it appears on the index
+// and gets its own page at /case-studies/<slug>.
+// Keep client-identifying names out of slugs and copy where anonymity was agreed.
+
+export type CaseStudy = {
+  slug: string
+  tag: string
+  clientLabel: string // anonymous descriptor shown in place of a client name
+  stat: string
+  statLabel: string
+  headline: string
+  subheadline: string
+  meta: { label: string; value: string }[]
+  situationTitle: string
+  situation: { title: string; body: string }[]
+  situationPullQuote: string
+  builtTitle: string
+  built: { title: string; body: string }[]
+  changed: string[]
+  patternNote: string
+}
+
+export const caseStudies: CaseStudy[] = [
+  {
+    slug: 'wa-mortgage-lender',
+    tag: 'FINANCIAL SERVICES',
+    clientLabel: 'WA mortgage-lending broker',
+    stat: '75%',
+    statLabel: "of an FTE's onboarding work, automated",
+    headline: 'Five-figure monthly platform replaced.',
+    subheadline:
+      'What we replaced, what we built, and what changed for a WA mortgage-lending broker.',
+    meta: [
+      { label: 'Industry', value: 'Mortgage aggregation' },
+      { label: 'Location', value: 'Western Australia' },
+      { label: 'Size', value: '20+ staff' },
+      { label: 'In business', value: '10+ years' },
+      { label: 'Decision-maker', value: 'Founder / CEO' },
+    ],
+    situationTitle: "The business was operating well. The machinery underneath wasn't keeping up.",
+    situation: [
+      {
+        title: "A five-figure monthly cost on a compliance platform that didn't quite fit.",
+        body: 'The third-party tool covered 80% of what was needed. The rest got filled in by hand. Recurring cost was real; the gaps it left were getting filled with people, every month.',
+      },
+      {
+        title: "Broker support firefighting questions that shouldn't need a person.",
+        body: "Brokers were calling and emailing support for information that already existed in the business. It just wasn't where they could find it.",
+      },
+      {
+        title: 'Onboarding hitting the volume ceiling.',
+        body: "New broker onboarding had become so manual the business couldn't keep up with intake demand. Roughly 80% of the work could be done without a person. A person was doing all of it.",
+      },
+    ],
+    situationPullQuote:
+      "When new broker intake started outpacing the team's ability to onboard them, the model broke. The reactive pattern wasn't going to scale.",
+    builtTitle: 'Three workstreams. Each targeting a different bottleneck.',
+    built: [
+      {
+        title: 'Custom compliance platform',
+        body: 'Multi-tenant platform built around how their work actually runs. Replaced the five-figure monthly off-the-shelf tool. Live in production.',
+      },
+      {
+        title: 'Broker self-serve chat',
+        body: "AI-led chat that lets brokers find answers they used to call support for. Trained on the business's own SOPs and internal information.",
+      },
+      {
+        title: 'Broker onboarding automation',
+        body: "Started by sitting in on the real onboarding workflow and timing every step. Found the 80% of the work that didn't need a person. Built the automation around that.",
+      },
+    ],
+    changed: [
+      'Five-figure monthly platform cost eliminated',
+      "75% of an FTE's worth of onboarding work automated",
+      'Broker support load expected to drop significantly once chat goes live',
+      'Ongoing engagement across multiple workstreams',
+    ],
+    patternNote:
+      'The pattern is the same one we see across WA financial services: a business operating well, with the machinery underneath not quite scaled to the ambition. The fix is rarely another off-the-shelf platform.',
+  },
+]
+
+export function getCaseStudy(slug: string) {
+  return caseStudies.find((c) => c.slug === slug)
+}

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link'
+import { FiArrowRight } from 'react-icons/fi'
+import Reveal from '../components/Reveal'
+import { caseStudies } from './data'
+
+export const metadata = {
+  title: 'Case studies · Extensa',
+  description: 'Real engagements with WA businesses: what was slowing them down, what we built, and what changed.',
+}
+
+export default function CaseStudiesPage() {
+  return (
+    <div className="bg-[--paper] text-[--ink] min-h-screen">
+      <main className="pt-28 sm:pt-36 pb-16 md:pb-24">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6">
+          <p className="eyebrow mb-3">Evidence</p>
+          <h1 className="font-display text-4xl md:text-5xl font-bold mb-5">Case studies</h1>
+          <p className="text-lg text-[--ink-soft] leading-relaxed max-w-2xl mb-12">
+            Real engagements: what was slowing the business down, what we built, and what changed.
+            Some clients are named, some aren&apos;t; the numbers are real either way.
+          </p>
+          <div className="grid md:grid-cols-2 gap-5">
+            {caseStudies.map((c, i) => (
+              <Reveal key={c.slug} delay={i * 80} className="h-full">
+                <Link href={`/case-studies/${c.slug}`} className="card card-accent p-7 md:p-8 flex flex-col h-full group">
+                  <p className="eyebrow mb-4">{c.tag}</p>
+                  <p className="font-display text-5xl font-bold text-[--signal-deep] leading-none">{c.stat}</p>
+                  <p className="mt-2 mb-5 font-mono text-sm text-[--ink-soft]">{c.statLabel}</p>
+                  <h2 className="font-display text-2xl font-semibold mb-3 pt-4 border-t border-[--line]">
+                    {c.headline}
+                  </h2>
+                  <p className="text-[--ink-soft] leading-relaxed flex-1">{c.subheadline}</p>
+                  <span className="inline-flex items-center gap-1 mt-5 text-sm font-semibold text-[--signal-deep] group-hover:underline">
+                    Read the case study <FiArrowRight className="w-4 h-4" />
+                  </span>
+                </Link>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -145,6 +145,12 @@ export default function Navbar() {
                             Work
                         </a>
                         <Link
+                            href="/case-studies"
+                            className={`${pathname.startsWith('/case-studies') ? 'text-[--accent-deep] font-semibold' : 'text-gray-600'} hover:text-[--accent-deep] transition duration-300`}
+                        >
+                            Case studies
+                        </Link>
+                        <Link
                             href="/financial-services"
                             className={`${pathname === '/financial-services' ? 'text-[--accent-deep] font-semibold' : 'text-gray-600'} hover:text-[--accent-deep] transition duration-300`}
                         >
@@ -211,6 +217,15 @@ export default function Navbar() {
                                 } hover:text-[--accent-deep] hover:bg-[--accent-soft] transition duration-300 cursor-pointer rounded-lg`}>
                             Work
                         </a>
+                        <Link
+                            href="/case-studies"
+                            onClick={handleMenuItemClick}
+                            className={`block px-3 py-2 ${pathname.startsWith('/case-studies')
+                                ? 'text-[--accent-deep] font-semibold bg-[--accent-soft]'
+                                : 'text-gray-600'
+                                } hover:text-[--accent-deep] hover:bg-[--accent-soft] transition duration-300 rounded-lg`}>
+                            Case studies
+                        </Link>
                         <div className="border-t border-gray-200 mt-2">
                             <a
                                 href="/#contact"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -248,6 +248,31 @@ export default function Home() {
           <div className="max-w-6xl mx-auto px-4 sm:px-6">
             <p className="eyebrow mb-3">Evidence</p>
             <h2 className="font-display text-3xl md:text-4xl font-bold mb-10">Recent work</h2>
+            <Reveal>
+              <Link
+                href="/case-studies/wa-mortgage-lender"
+                className="card card-accent p-7 md:p-9 mb-5 flex flex-col md:flex-row md:items-center gap-6 md:gap-12 group"
+              >
+                <div className="shrink-0">
+                  <p className="eyebrow mb-3">FEATURED CASE STUDY</p>
+                  <p className="font-display text-5xl md:text-6xl font-bold text-[--signal-deep] leading-none">75%</p>
+                  <p className="mt-2 font-mono text-sm text-[--ink-soft] max-w-[16rem]">
+                    of an FTE&apos;s onboarding work, automated
+                  </p>
+                </div>
+                <div className="flex-1 md:border-l md:border-[--line] md:pl-12">
+                  <h3 className="font-display text-2xl font-semibold mb-2">
+                    Five-figure monthly platform replaced.
+                  </h3>
+                  <p className="text-[--ink-soft] leading-relaxed">
+                    What we replaced, what we built, and what changed for a WA mortgage-lending broker.
+                  </p>
+                  <span className="inline-flex items-center gap-1 mt-4 text-sm font-semibold text-[--signal-deep] group-hover:underline">
+                    Read the case study <FiArrowRight className="w-4 h-4" />
+                  </span>
+                </div>
+              </Link>
+            </Reveal>
             <div className="grid md:grid-cols-3 gap-5">
               {work.map((w, i) => (
                 <Reveal key={w.title} delay={i * 80} className="h-full">
@@ -422,6 +447,7 @@ export default function Home() {
             <p>AI &amp; custom software · Perth, Western Australia</p>
           </div>
           <nav className="flex gap-6">
+            <Link href="/case-studies" className="hover:text-white">Case studies</Link>
             <Link href="/financial-services" className="hover:text-white">Financial services</Link>
             <a href={CAL_URL} target="_blank" rel="noopener noreferrer" className="hover:text-white">Book a call</a>
           </nav>


### PR DESCRIPTION
Adds an anonymous case-studies section driven by a single data file.

- `/case-studies` index page listing all case studies
- `/case-studies/wa-mortgage-lender` — full case study (dark hero with 75% stat, situation, three workstreams, results, CTA), fully anonymized per client agreement
- Data-driven: new case studies are just a new entry in `app/case-studies/data.ts`
- Navbar (desktop + mobile) and footer links, plus a featured case-study banner on the homepage Recent work section

🤖 Generated with [Claude Code](https://claude.com/claude-code)